### PR TITLE
Push task real flags

### DIFF
--- a/src/task/task.asm
+++ b/src/task/task.asm
@@ -22,10 +22,7 @@ task_return:
     push dword [ebx+40]
 
     ; Push the flags
-    pushf
-    pop eax
-    or eax, 0x200
-    push eax
+    push dword [ebx+36]
 
     ; Push the code segment
     push dword [ebx+32]

--- a/src/task/task.c
+++ b/src/task/task.c
@@ -230,6 +230,8 @@ int task_init(struct task *task, struct process *process)
     task->registers.cs = USER_CODE_SEGMENT;
     task->registers.esp = PEACHOS_PROGRAM_VIRTUAL_STACK_ADDRESS_START;
 
+    task->registers.flags = 0b1000000010; // RESERVED + INTERRUPT_ENABLE_FLAG
+    
     task->process = process;
 
     return 0;


### PR DESCRIPTION
In `task_return` function we push values from kernel EFLAGS but we should push saved flags instead. Also this PR initialize flags for user program