### PR TITLE
fix: ending_sector_pos bug

### DIFF
--- a/src/fs/fat/fat16.c
+++ b/src/fs/fat/fat16.c
@@ -243,7 +243,7 @@ int fat16_get_root_directory(struct disk *disk, struct fat_private *fat_private,
     directory->item = dir;
     directory->total = total_items;
     directory->sector_pos = root_dir_sector_pos;
-    directory->ending_sector_pos = root_dir_sector_pos + (root_dir_size / disk->sector_size);
+    directory->ending_sector_pos = root_dir_sector_pos + total_sectors - 1;
 out:
     return res;
 


### PR DESCRIPTION
if start pos is 0

if root_dir_size is 512
  -> ending_sector_pos need to be 0 because we only need to read one sector
  -> root_dir_size / disk->sector_size == 1
  -> total_sectors == 1

if root_dir_size is 511
  -> ending_sector_pos need to be 0
  -> root_dir_size / disk->sector_size == 0
  -> total_sectors == 1

if root_dir_size is 513
  -> ending_sector_pos need to be 1, we need to read one more sector
  -> root_dir_size / disk->sector_size == 1
  -> total_sectors == 2

so we need to change the code to `total_sectors - 1`